### PR TITLE
[FEATURE] add option to convert referenced default language elements to all language insert records

### DIFF
--- a/Classes/Controller/Tv2fluidgeController.php
+++ b/Classes/Controller/Tv2fluidgeController.php
@@ -194,11 +194,8 @@ class Tx_SfTv2fluidge_Controller_Tv2fluidgeController extends Tx_Extbase_MVC_Con
 	public function convertReferenceElementsAction($formdata = NULL) {
 		$this->sharedHelper->setUnlimitedTimeout();
 
-		$useParentUidForTranslations = FALSE;
-		if (intval($formdata['useparentuidfortranslations']) === 1) {
-			$useParentUidForTranslations = TRUE;
-		}
-		$numRecords = $this->referenceElementHelper->convertReferenceElements($useParentUidForTranslations);
+		$this->referenceElementHelper->initFormData($formdata);
+		$numRecords = $this->referenceElementHelper->convertReferenceElements();
 		$this->view->assign('numRecords', $numRecords);
 	}
 

--- a/Classes/Service/SharedHelper.php
+++ b/Classes/Service/SharedHelper.php
@@ -915,7 +915,8 @@ class Tx_SfTv2fluidge_Service_SharedHelper implements t3lib_Singleton {
 						'CType',
 						'records',
 						'colPos',
-						'sorting'
+						'sorting',
+						'sys_language_uid'
 					)
 				);
 			}

--- a/Resources/Private/Language/locallang.xml
+++ b/Resources/Private/Language/locallang.xml
@@ -24,6 +24,7 @@
             <label index="label_mark_deleted">Flag original FCE as deleted</label>
 			<label index="label_mark_deleted_tv_template">Flag original Templavoila template as deleted</label>
 			<label index="label_use_parent_uid_for_translations">Use parent uid for content translations</label>
+			<label index="label_use_all_language_if_default_language_is_referenced">Use all language insert record if default language record is referenced</label>
             <label index="label_create_reference">Create shortcut content element for TV references</label>
 			<label index="label_delete_unref">Delete unused Elements</label>
             <label index="label_convert_ref">Convert references</label>

--- a/Resources/Private/Templates/Tv2fluidge/IndexConvertReferenceElements.html
+++ b/Resources/Private/Templates/Tv2fluidge/IndexConvertReferenceElements.html
@@ -14,6 +14,9 @@
 		<f:form.checkbox id="useparentuidfortranslations" name="useparentuidfortranslations" property="useparentuidfortranslations" value="1" checked="false"/>
 		<label for="useparentuidfortranslations"><f:translate key="label_use_parent_uid_for_translations"/></label>
 		<br>
+		<f:form.checkbox id="usealllangifdefaultlangisreferenced" name="usealllangifdefaultlangisreferenced" property="usealllangifdefaultlangisreferenced" value="1" checked="false"/>
+		<label for="usealllangifdefaultlangisreferenced"><f:translate key="label_use_all_language_if_default_language_is_referenced"/></label>
+		<br>
         <f:form.submit value="{f:translate(key: 'label_start')}" class="start"/>
     </f:form>
 


### PR DESCRIPTION
Optional it allows to convert default language references to be converted to all language insert records.
With correct config.sys_language_overlay setting this would work like the templavoila references to default records.
If the referenced element is not default language or has no parent language record, the normal behaviour is used (that is why the option regarding whether to use parent uid for insert records or translated content element uid might still result in differences).
