### PR TITLE
Convert TV objects only

### DIFF
--- a/Classes/Service/ReferenceElementHelper.php
+++ b/Classes/Service/ReferenceElementHelper.php
@@ -118,7 +118,13 @@ class Tx_SfTv2fluidge_Service_ReferenceElementHelper implements t3lib_Singleton 
 				$contentElementPid = (int)$contentElement['pid'];
 				if ($this->sharedHelper->isContentElementAvailable($contentUid)) {
 					if ($contentElementPid !== $pid) {
-						$numRecords += $this->convertReferenceToShortcut($contentUid, $pid, $field, $position, $fceUid);
+						$pageContentUids = $this->sharedHelper->getFlatTvContentArrayForPage($contentElementPid);
+						if (in_array($contentUid, $pageContentUids)) {
+							$numRecords += $this->convertReferenceToShortcut($contentUid, $pid, $field, $position, $fceUid);
+						}
+						else {
+							$numRecords += $this->moveReferenceToPage($contentUid, $pid);
+						}
 					} else if ($contentElement['CType'] == 'templavoila_pi1') {
 						$numRecords += $this->convertReferencesInsideFceToShortcut($contentUid, $pid);
 					}
@@ -162,6 +168,23 @@ class Tx_SfTv2fluidge_Service_ReferenceElementHelper implements t3lib_Singleton 
 			++$numRecords;
 		}
 		return $numRecords;
+	}
+
+	/**
+	 * moves a reference content element to the given page
+	 *
+	 * @param int $contentUid
+	 * @param int $pid
+	 * @return int
+	 */
+	protected function moveReferenceToPage($contentUid, $pid) {
+		$GLOBALS['TYPO3_DB']->exec_UPDATEquery(
+			'tt_content',
+			'uid = ' . (int)$contentUid,
+			array(
+				'pid' => (int)$pid,
+			)
+		);
 	}
 
 	protected function convertShortcutToAllLangShortCut($contentUid, $targetUid) {

--- a/Classes/Service/SharedHelper.php
+++ b/Classes/Service/SharedHelper.php
@@ -349,6 +349,22 @@ class Tx_SfTv2fluidge_Service_SharedHelper implements t3lib_Singleton {
 	}
 
 	/**
+	 * Returns an flat array (ce uids only) of TV FlexForm content fields for the page with the given UID.
+	 * The content elements are seperated by comma
+	 *
+	 * @param int $pageUid
+	 * @return array
+	 */
+	public function getFlatTvContentArrayForPage($pageUid) {
+		$contentUids = array();
+		$tvContentArray = $this->getTvContentArrayForPage($pageUid);
+		foreach ($tvContentArray as $field => $contentUidString) {
+			$contentUids = array_merge($contentUids, t3lib_div::trimExplode(',', $contentUidString, TRUE));
+		}
+		return $contentUids;
+	}
+
+	/**
 	 * Returns an array of TV FlexForm content fields for the tt_content element with the given uid.
 	 * The content elements are seperated by comma
 	 *


### PR DESCRIPTION
Check type of object before conversion to avoid infinite loops when object has changed from TV object to e.g. textpic.
