### PR TITLE
Unreferenced elements must be set to -2

### DIFF
--- a/Classes/Service/UnreferencedElementHelper.php
+++ b/Classes/Service/UnreferencedElementHelper.php
@@ -169,7 +169,7 @@ class Tx_SfTv2fluidge_Service_UnreferencedElementHelper implements t3lib_Singlet
 	 */
 	private function markNegativeColPos($uids) {
 		$where = 'uid IN (' . implode(',', $uids) . ')';
-		$GLOBALS['TYPO3_DB']->exec_UPDATEquery('tt_content', $where, array('colPos' => -1, 'tstamp' => time()));
+		$GLOBALS['TYPO3_DB']->exec_UPDATEquery('tt_content', $where, array('colPos' => -2, 'tstamp' => time()));
 
 		$this->logHelper->logMessage('===== ' . __CLASS__ . ' - ' . __FUNCTION__ . ' =====');
 		$this->logHelper->logMessage($GLOBALS['TYPO3_DB']->debug_lastBuiltQuery);

--- a/Resources/Private/Language/locallang.xml
+++ b/Resources/Private/Language/locallang.xml
@@ -27,7 +27,7 @@
             <label index="label_warning">Warning</label>
             <label index="label_fce">Flexible Content Element</label>
             <label index="label_ge">Grid Element</label>
-			<label index="label_mark_as_negative_col_pos">Mark unreferenced elements as "colPos = -1" instead</label>
+			<label index="label_mark_as_negative_col_pos">Mark unreferenced elements as "colPos = -2" instead</label>
             <label index="label_mark_deleted">Flag original FCE as deleted</label>
 			<label index="label_mark_deleted_tv_template">Flag original Templavoila template as deleted</label>
 			<label index="label_use_parent_uid_for_translations">Use parent uid for content translations</label>


### PR DESCRIPTION
Gridelements uses -1 as the default colPos value for child elements of a container.
Unused elements are moved to colPos -2 instead.