### PR TITLE
Respect inheritance of TV templates

### DIFF
--- a/Classes/Service/SharedHelper.php
+++ b/Classes/Service/SharedHelper.php
@@ -221,6 +221,10 @@ class Tx_SfTv2fluidge_Service_SharedHelper implements t3lib_Singleton {
 					$tvTemplateObjectUid = $myPageRecord['tx_templavoila_next_to'];
 					break;
 				}
+				if ($myPageRecord['tx_templavoila_to']) {
+					$tvTemplateObjectUid = $myPageRecord['tx_templavoila_to'];
+					break;
+				}
 			}
 		}
 		return $tvTemplateObjectUid;


### PR DESCRIPTION
Since TV templates are inherited automatically (which is not the case for backend layouts), we need to stop the rootline in any case, nut just for the next level values.
Otherwise the rootline will be fully searched and if no next level is set at all it will return 0 as the layout value.

The next level template just overrides the inheritance, so the order must be next level template first followed by template - and if nothing is found, get the parent level.