### PR TITLE
Respect integers as posssible datastructure values

### DIFF
--- a/Classes/Service/SharedHelper.php
+++ b/Classes/Service/SharedHelper.php
@@ -293,8 +293,13 @@ class Tx_SfTv2fluidge_Service_SharedHelper implements t3lib_Singleton {
 		$flexform = NULL;
 		if ($this->getTemplavoilaStaticDsIsEnabled()) {
 			$toRecord = $this->getTvTemplateObject($uidTvDs);
-			$path = t3lib_div::getFileAbsFileName($toRecord['datastructure']);
-			$flexform = simplexml_load_file($path);
+			if (\TYPO3\CMS\Core\Utility\MathUtility::canBeInterpretedAsInteger($toRecord['datastructure'])) {
+				$dsRecord = $this->getTvDatastructure($uidTvDs);
+				$flexform = @simplexml_load_string($dsRecord['dataprot']);
+			} else {
+				$path = \TYPO3\CMS\Core\Utility\GeneralUtility::getFileAbsFileName($toRecord['datastructure']);
+				$flexform = @simplexml_load_string(file_get_contents($path));
+			}
 		}
 		else {
 			$dsRecord = $this->getTvDatastructure($uidTvDs);


### PR DESCRIPTION
The datastructure field of template objects might still contain integer values, so the check should be doubled to fetch the datastructure from the other table just in case.